### PR TITLE
Fix issue in FunctionFinder

### DIFF
--- a/src/main/java/fr/univartois/sonargo/gotest/FunctionFinder.java
+++ b/src/main/java/fr/univartois/sonargo/gotest/FunctionFinder.java
@@ -62,6 +62,10 @@ public class FunctionFinder {
 	    LOGGER.warn("This function name is not correct: " + s);
 	    return null;
 	}
+	int indexCloseParen = s.indexOf(")");
+	if (indexCloseParen < indexParen) {
+	    indexTesting = s.indexOf("Test", indexCloseParen);
+	}
 
 	return s.substring(indexTesting, indexParen);
     }

--- a/src/test/java/fr/univartois/sonargo/FunctionFinderTest.java
+++ b/src/test/java/fr/univartois/sonargo/FunctionFinderTest.java
@@ -30,6 +30,8 @@ public class FunctionFinderTest extends AbstractSonarTest {
 	    assertEquals("TestAverage", f.searchInLine("func TestAverage(t *testing.T)"));
 	    assertEquals("TestGutterBalls", f.searchInLine("func TestGutterBalls(t *testing.T)"));
 	    assertEquals("TestOnePinOnEveryThrow", f.searchInLine("func TestOnePinOnEveryThrow(t *testing.T) {"));
+	    assertEquals("TestCaseOne", f.searchInLine("func (suite *TestSuite) TestCaseOne() {"));
+	    assertEquals("TestCaseTwo", f.searchInLine("func (suite *ExampleSuite) TestCaseTwo() {"));
 	} catch (IOException e) {
 	    // TODO Auto-generated catch block
 	    e.printStackTrace();


### PR DESCRIPTION
### PR Contribution 
This PR fixes the FunctionFinder's problem so that it finds test names correctly for test suites. 

### Bug description
We use [stretchr's testify suite](https://godoc.org/github.com/stretchr/testify/suite) in our go projects, so the test cases in our projects are like the example below: 

```
type ExampleTestSuite struct {
    suite.Suite
    VariableThatShouldStartAtFive int
}

func (suite *ExampleTestSuite) TestExample() {
    suite.Equal(5, suite.VariableThatShouldStartAtFive)
}
```

The bug is when FunctionFinder scans test files to find all testName -> testFilePath mappings, it finds the wrong function names. For example, when scans the code above, the FunctionFinder thinks the test name is `TestSuite) TestExample`, but the correct function name is `TestExample`.

In later step, the GoJunitParser finds function names in the xml file. Then GoJunitParser uses the function name `TestExample` to find the `filePath` in the mapping that FunctionFinder provided. Due to the FunctionFinder found the wrong function name, so the GoJunitParser finds `filePath` to be `null`. This `null` breaks the GoTestReportSaver in line 47:
```
// Due to value.getFile() returns null,  this line throws error
InputFile file = context.fileSystem().inputFile(predicates.hasAbsolutePath(value.getFile()));
```

We currently work around this issue by renaming our suites to be `ExampleSuite` so that it doesn't include the `Test` keyword. However it would be much better to get this problem fixed so that we can still use generic `TestSuite` names.

### Steps to Reproduce

1. Use test suite in golang project and name the suite as `TestSuite`
2. Generate junit test report.
3. Run sonar-scanner on this project 
p.s (Only check test metric is enough, since coverage and linter metrics have no problems)

### Content of your sonar-project.properties
All default settings


### Versions
Server: 6.5
Sonar-Scanner: 3.0.3.778-macosx
Go version: 1.8.3
OS: macOS Sierra 10.12.6
gometalinter: 1.2.1