### PR TITLE
Update README to show how to leverage gocov test ./...

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ gometalinter.v1 --checkstyle > report.xml
 
 # Coverage (since release 1.1)
 
-For coverage metrics you must have a `coverage.xml` (cobertura xml format) file *per package*.
+For coverage metrics you must have one or multiple  `coverage.xml` (cobertura xml format) files.
 
 * First install the tools for converting a coverprofile in cobertura file:
 ```shell
@@ -88,13 +88,25 @@ go get github.com/axw/gocov/...
 go get github.com/AlekSi/gocov-xml
 ```
 
-* Then for all packages execute those commands:
+* Then from the root of your project:
+```shell
+gocov test ./... | gocov-xml > coverage.xml
+```
+
+Note that `gocov test ./...` internally calls `go test` with the `-coverprofile` flag for
+all folders and subfolders, and assembles the coverprofile accordingly by itself (this is
+nessecary, as Golang up to 1.9 did not support the combination `gocov test ./... -coverprofile=...`).
+
+If you want to invoke `go test` manually, you need to do this and the conversion by each
+package by yourself. For example:
+
+* For all packages execute those commands:
 ```shell
 go test -coverprofile=cover.out
 gocov convert cover.out | gocov-xml > coverage.xml
 ```
 
-You must end-up with one coverage file per directory:
+You then end-up with one coverage file per directory:
 ```
 pkg1/coverage.xml
 pkg2/coverage.xml
@@ -103,7 +115,7 @@ pkg3/coverage.xml
 ```
 
 
-This is an example of script for create all coverage files for all packages in one time. 
+This is an example of script for create all coverage files for all packages in one time.
 
 
 ```bash
@@ -121,10 +133,10 @@ do
     cd $D
     go test -coverprofile=cover.out
     gocov convert cover.out | gocov-xml > coverage.xml
-    cd .. 
+    cd ..
 done
 ```
-or 
+or
 
 ```bash
 go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/cover.out {{.ImportPath}}"{{end}}' ./... | xargs -L 1 sh -c


### PR DESCRIPTION
Nothing much to say... Instead of juggling with walking trough folders and assembling coverage files one by one - one can simply use `gocov test ./...`.